### PR TITLE
bug fix: failure status shoudn't be nulled

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -426,8 +426,6 @@ App::get('/v1/account/sessions/oauth2/:provider/redirect')
             throw new Exception(Exception::PROJECT_INVALID_FAILURE_URL);
         }
 
-        $state['failure'] = null;
-
         $accessToken = $oauth2->getAccessToken($code);
         $refreshToken = $oauth2->getRefreshToken($code);
         $accessTokenExpiry = $oauth2->getAccessTokenExpiry($code);


### PR DESCRIPTION
## What does this PR do?

For some reason the failure status was set to null and it prevented to get the failure URL in the route `/v1/account/sessions/oauth2/:provider/redirect`

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes
